### PR TITLE
Overridden 3 methods from the LocationListener Interface

### DIFF
--- a/app/src/main/java/com/udacity/project4/locationreminders/savereminder/selectreminderlocation/SelectLocationFragment.kt
+++ b/app/src/main/java/com/udacity/project4/locationreminders/savereminder/selectreminderlocation/SelectLocationFragment.kt
@@ -433,6 +433,20 @@ class SelectLocationFragment : BaseFragment(),
         }
     }
 
+    /**
+     * Theses methods are overridden to prevent app from crashing
+     * on lower APIs 30 or Lower
+     */
+    override fun onProviderEnabled(provider: String) {
+        //super.onProviderEnabled(provider)
+    }
 
+    override fun onProviderDisabled(provider: String) {
+        //super.onProviderDisabled(provider)
+    }
+
+    override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) {
+        //super.onStatusChanged(provider, status, extras)
+    }
 
 }


### PR DESCRIPTION
 They should be implemented to prevent the app from crashing on API 29 or lower, from API 30 and higher we don't need to override these methods since they have default implementation which was not the case on API 29 or lower